### PR TITLE
fix: don't do a for loop when adding the roles

### DIFF
--- a/src/events/guildMemberAdd.ts
+++ b/src/events/guildMemberAdd.ts
@@ -7,8 +7,6 @@ export default eventModule({
 	async execute(member: GuildMember) {
 		// TODO: This should be inferred
 		const requiredRoles = ["980118655738212407"];
-		for (const roleId of requiredRoles) {
-			await member.roles.add(roleId);
-		}
+		await member.roles.add(requiredroles);
 	},
 });


### PR DESCRIPTION
as Evo said in Discord, we can directly pass the ID of the roles, so there's no need to do a for loop.

https://canary.discord.com/channels/889026545715400705/980201243504955432/1011810501187080213