### PR TITLE
refactor: change random status message/type

### DIFF
--- a/src/utils/randomStatus.ts
+++ b/src/utils/randomStatus.ts
@@ -11,7 +11,7 @@ const statues: [
 	[ActivityType.Watching, "sern bots", "dnd"],
 	[ActivityType.Watching, "github stars go brrr", "online"],
 	[ActivityType.Listening, "Spotify", "dnd"],
-	[ActivityType.Playing, "bofa", "idle"],
+	[ActivityType.Listening, "what's bofa", "idle"],
 ];
 
 export function randomStatus(client: Client) {


### PR DESCRIPTION
Makes more sense to listen for the message `what's bofa` so that people will ask it in chat.