### PR TITLE
fix: fix tag link for docs

### DIFF
--- a/tags.json
+++ b/tags.json
@@ -32,7 +32,7 @@
     },
     {
         "name": "docs",
-        "content": "Please read the documentation of sern [*here*](<https://sern.dev/docs/intro>)",
+        "content": "Please read the documentation of sern [*here*](<https://sern.dev/v4/reference/getting-started/>)",
         "keywords": ["sern docs"]
     },
     {


### PR DESCRIPTION
fixes the link when you type "sern docs" from linking to old docs page (and subsequently not working)